### PR TITLE
fix: Google's 'translate.google.cn' address is no longer maintained,s…

### DIFF
--- a/src/packages/src/index.vue
+++ b/src/packages/src/index.vue
@@ -449,7 +449,7 @@ export default {
       };
       const createScript = () => {
         this.dynamicLoadJs(
-          "//translate.google.cn/translate_a/element.js?cb=googleTranslateElementInit",
+          "//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit",
           () => {
             this.GTranslateFireEvent = (a, b) => {
               try {


### PR DESCRIPTION
fix: Google's 'translate.google.cn' address is no longer maintained,so needs to be replaced by 'translate.google.com'

Limited ability, make it better~
